### PR TITLE
ci: add minimal GitHub Actions workflow (refs #6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Lint (if present)
+        run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));process.exit(p.scripts&&p.scripts.lint?0:1)" \
+            && npm run lint \
+            || echo "No lint script; skipping."


### PR DESCRIPTION
Refs #6.

Adds a minimal GitHub Actions CI workflow that runs on push and pull_request, installs via npm ci, and runs npm test. If a lint script exists, it runs npm run lint as well.