### PR TITLE
chore: add .editorconfig (refs #5)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Refs #5.

Adds an .editorconfig to standardize whitespace/line endings (JS/JSON/MD defaults; keeps trailing whitespace in Markdown).