### PR TITLE
chore: ignore env + secrets patterns (refs #8)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,14 @@
 node_modules
 npm-debug.log
+
+# env / secrets
 .env
+.env.*
+*.pem
+*.key
+secrets*
+*secret*
+
 .git
 .gitignore
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
-node_modules
-.env
+node_modules/
 .DS_Store
+
+# env / secrets
+.env
+.env.*
+*.pem
+*.key
+secrets*
+*secret*


### PR DESCRIPTION
Refs #8.

Tightens .gitignore and .dockerignore to exclude .env variants and common secret/key patterns, reducing accidental leakage risk.