### PR TITLE
feat: harden paywall UX states + retry (refs #12)

### DIFF
--- a/server.js
+++ b/server.js
@@ -305,17 +305,31 @@ app.get(
       <div class="paywall-card">
         <div class="paywall-title">Unlock this post</div>
         <div class="paywall-meta">Price: <strong>${escapeHtml(priceLine)}</strong></div>
-        <button class="btn" id="unlockBtn">Unlock for ${escapeHtml(post.price_sats)} sats</button>
+
+        <div class="status" id="status">To continue, pay once via Lightning.</div>
+        <div class="status" id="statusHelp">After payment, this page unlocks automatically on this device.</div>
+
+        <div class="paywall-actions">
+          <button class="btn" id="getInvoiceBtn">Get invoice</button>
+          <button class="btn btn-secondary" id="newInvoiceBtn" hidden>Get a new invoice</button>
+        </div>
+
         <div class="invoice" id="invoice" hidden>
           <div class="invoice-row">
             <div class="muted">Invoice</div>
             <code class="bolt11" id="bolt11"></code>
+            <div class="invoice-actions">
+              <button class="btn btn-secondary" id="copyInvoiceBtn" type="button">Copy invoice</button>
+            </div>
           </div>
           <div class="invoice-row">
             <div class="muted">QR</div>
             <div id="qrcode"></div>
           </div>
-          <div class="status" id="status">Waiting for payment…</div>
+          <div class="invoice-actions">
+            <button class="btn btn-secondary" id="refreshStatusBtn" type="button">Refresh status</button>
+            <button class="btn btn-secondary" id="reloadBtn" type="button">Reload page</button>
+          </div>
         </div>
       </div>
     </section>

--- a/static/pay.js
+++ b/static/pay.js
@@ -5,20 +5,33 @@
   const slug = paywall.dataset.slug;
   const price = Number(paywall.dataset.price || 0);
 
-  const btn = document.getElementById('unlockBtn');
+  const statusEl = document.getElementById('status');
+  const statusHelpEl = document.getElementById('statusHelp');
+
+  const getInvoiceBtn = document.getElementById('getInvoiceBtn');
+  const newInvoiceBtn = document.getElementById('newInvoiceBtn');
+
   const invoiceBox = document.getElementById('invoice');
   const bolt11El = document.getElementById('bolt11');
-  const statusEl = document.getElementById('status');
+  const copyInvoiceBtn = document.getElementById('copyInvoiceBtn');
+  const refreshStatusBtn = document.getElementById('refreshStatusBtn');
+  const reloadBtn = document.getElementById('reloadBtn');
   const qrEl = document.getElementById('qrcode');
 
   let pollTimer = null;
   let pollInFlight = false;
   let pollStartedAt = 0;
+  let currentInvoice = null;
+  let consecutiveErrors = 0;
+
+  const MAX_POLL_MS = 15 * 60 * 1000; // keep in sync with server-side state exp
+  const JUST_PAID_MS = 5 * 60 * 1000;
+  const paidKey = `paywritr:lastPaid:${slug}`;
 
   async function createInvoice() {
     const r = await fetch(`/api/invoice?slug=${encodeURIComponent(slug)}`);
-    const data = await r.json();
-    if (!r.ok) throw new Error(data.error || 'failed');
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(data.error || 'Could not create an invoice.');
     return data;
   }
 
@@ -27,13 +40,21 @@
       `/api/invoice/status?payment_hash=${encodeURIComponent(payment_hash)}&state=${encodeURIComponent(state)}`,
       { credentials: 'same-origin' }
     );
-    const data = await r.json();
-    if (!r.ok) throw new Error(data.error || 'failed');
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(data.error || 'Could not check payment status.');
     return data.paid === true;
   }
 
-  function setStatus(txt) {
-    statusEl.textContent = txt;
+  function setStatus(txt, help) {
+    statusEl.textContent = txt || '';
+    if (typeof help === 'string') statusHelpEl.textContent = help;
+  }
+
+  function setButtons({ canGetInvoice, canNewInvoice, canRefresh }) {
+    getInvoiceBtn.disabled = !canGetInvoice;
+    newInvoiceBtn.hidden = !canNewInvoice;
+    newInvoiceBtn.disabled = !canNewInvoice;
+    refreshStatusBtn.disabled = !canRefresh;
   }
 
   function stopPolling() {
@@ -42,66 +63,159 @@
     pollInFlight = false;
   }
 
+  function showIntro() {
+    invoiceBox.hidden = true;
+    setStatus('To continue, pay once via Lightning.', 'After payment, this page unlocks automatically on this device.');
+    setButtons({ canGetInvoice: true, canNewInvoice: false, canRefresh: false });
+  }
+
+  function showInvoice(inv) {
+    invoiceBox.hidden = false;
+    bolt11El.textContent = inv.payment_request;
+    qrEl.innerHTML = '';
+    // qrcode.js global
+    new QRCode(qrEl, {
+      text: inv.payment_request,
+      width: 180,
+      height: 180,
+      correctLevel: QRCode.CorrectLevel.M,
+    });
+
+    setStatus('Scan to pay or copy the invoice.', 'Keep this tab open until payment completes.');
+    setButtons({ canGetInvoice: false, canNewInvoice: true, canRefresh: true });
+  }
+
+  function markPaidAndReload(inv) {
+    try {
+      sessionStorage.setItem(paidKey, JSON.stringify({ payment_hash: inv.payment_hash, state: inv.state, ts: Date.now() }));
+    } catch {}
+    setStatus('Payment confirmed. Unlocking…', 'One moment.');
+    window.location.reload();
+  }
+
+  async function tickOnce() {
+    if (!currentInvoice) return;
+
+    if (Date.now() - pollStartedAt > MAX_POLL_MS) {
+      stopPolling();
+      setStatus('This invoice expired.', 'Generate a new invoice to try again.');
+      setButtons({ canGetInvoice: false, canNewInvoice: true, canRefresh: false });
+      return;
+    }
+
+    if (pollInFlight) return;
+    pollInFlight = true;
+    try {
+      const paid = await checkPaid(currentInvoice.payment_hash, currentInvoice.state);
+      consecutiveErrors = 0;
+      if (paid) {
+        stopPolling();
+        markPaidAndReload(currentInvoice);
+        return;
+      }
+      setStatus('Waiting for payment…', 'If you paid in your wallet, we’ll unlock as soon as it confirms.');
+    } catch {
+      consecutiveErrors += 1;
+      if (consecutiveErrors >= 3) {
+        setStatus('Still waiting for confirmation.', 'If your wallet shows the payment as sent, try “Refresh status” or wait a moment.');
+      }
+    } finally {
+      pollInFlight = false;
+    }
+  }
+
   function startPolling(inv) {
     stopPolling();
     pollStartedAt = Date.now();
+    currentInvoice = inv;
+    consecutiveErrors = 0;
 
-    const MAX_POLL_MS = 15 * 60 * 1000; // keep in sync with server-side state exp
+    const loop = async () => {
+      pollTimer = setTimeout(loop, 2000);
+      await tickOnce();
+    };
 
-    const tick = async () => {
-      pollTimer = setTimeout(tick, 2000);
-      if (pollInFlight) return;
-      if (Date.now() - pollStartedAt > MAX_POLL_MS) {
-        stopPolling();
-        setStatus('Invoice expired. Please create a new invoice.');
-        btn.disabled = false;
+    loop();
+  }
+
+  async function createAndShowInvoice() {
+    setButtons({ canGetInvoice: false, canNewInvoice: false, canRefresh: false });
+    setStatus('Generating invoice…', 'This usually takes a few seconds.');
+    try {
+      const inv = await createInvoice();
+      showInvoice(inv);
+      startPolling(inv);
+      return;
+    } catch (e) {
+      stopPolling();
+      currentInvoice = null;
+      invoiceBox.hidden = true;
+      setStatus('Couldn’t create an invoice.', 'Please check your connection and try again in a moment.');
+      setButtons({ canGetInvoice: true, canNewInvoice: false, canRefresh: false });
+    }
+  }
+
+  getInvoiceBtn.addEventListener('click', createAndShowInvoice);
+  newInvoiceBtn.addEventListener('click', () => {
+    stopPolling();
+    currentInvoice = null;
+    createAndShowInvoice();
+  });
+
+  refreshStatusBtn.addEventListener('click', async () => {
+    await tickOnce();
+  });
+
+  reloadBtn.addEventListener('click', () => window.location.reload());
+
+  copyInvoiceBtn.addEventListener('click', async () => {
+    const txt = bolt11El.textContent || '';
+    if (!txt) return;
+    try {
+      await navigator.clipboard.writeText(txt);
+      setStatus('Invoice copied.', statusHelpEl.textContent);
+    } catch {
+      // ignore
+    }
+  });
+
+  // If we just observed a payment and reloaded but are still paywalled,
+  // it likely means the browser blocked the unlock cookie.
+  (async () => {
+    try {
+      const raw = sessionStorage.getItem(paidKey);
+      if (!raw) {
+        showIntro();
+        return;
+      }
+      const data = JSON.parse(raw);
+      if (!data || !data.payment_hash || !data.state || !data.ts) {
+        sessionStorage.removeItem(paidKey);
+        showIntro();
+        return;
+      }
+      if (Date.now() - Number(data.ts) > JUST_PAID_MS) {
+        sessionStorage.removeItem(paidKey);
+        showIntro();
         return;
       }
 
-      pollInFlight = true;
-      try {
-        const paid = await checkPaid(inv.payment_hash, inv.state);
-        if (paid) {
-          stopPolling();
-          setStatus('Paid. Reloading…');
-          window.location.reload();
-          return;
-        }
-      } catch (e) {
-        // transient errors happen; keep polling quietly
-      } finally {
-        pollInFlight = false;
+      // Re-check status; if it is paid but still locked, guide user about cookies.
+      const paid = await checkPaid(String(data.payment_hash), String(data.state));
+      if (paid) {
+        setStatus(
+          'Payment confirmed, but we couldn’t save your unlock.',
+          'Your browser may be blocking cookies for this site. Enable cookies, then reload.'
+        );
+        setButtons({ canGetInvoice: false, canNewInvoice: false, canRefresh: true });
+        invoiceBox.hidden = true;
+        return;
       }
-    };
 
-    tick();
-  }
-
-  btn.addEventListener('click', async () => {
-    btn.disabled = true;
-    btn.textContent = 'Creating invoice…';
-    try {
-      const inv = await createInvoice();
-      invoiceBox.hidden = false;
-      bolt11El.textContent = inv.payment_request;
-      qrEl.innerHTML = '';
-      // qrcode.js global
-      new QRCode(qrEl, {
-        text: inv.payment_request,
-        width: 180,
-        height: 180,
-        correctLevel: QRCode.CorrectLevel.M,
-      });
-
-      setStatus('Waiting for payment…');
-      startPolling(inv);
-
-      btn.textContent = `Unlock for ${price} sats`;
-    } catch (e) {
-      stopPolling();
-      btn.disabled = false;
-      btn.textContent = `Unlock for ${price} sats`;
-      alert(e.message);
+      sessionStorage.removeItem(paidKey);
+      showIntro();
+    } catch {
+      showIntro();
     }
-  });
+  })();
 })();

--- a/static/style.css
+++ b/static/style.css
@@ -39,8 +39,12 @@ a:hover{opacity:.85}
 .paywall-meta{color:var(--muted);font-size:14px;margin-bottom:12px}
 .btn{appearance:none;border:1px solid var(--fg);background:var(--fg);color:#fff;border-radius:999px;padding:10px 14px;font-weight:600;cursor:pointer}
 .btn:hover{opacity:.92}
+.btn:disabled{opacity:.6;cursor:not-allowed}
+.btn-secondary{background:#fff;color:var(--fg)}
+.paywall-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
 .invoice{margin-top:14px;border-top:1px solid var(--border);padding-top:14px}
 .invoice-row{margin-bottom:12px}
+.invoice-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}
 .bolt11{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;background:#fff;border:1px solid var(--border);padding:10px;border-radius:10px;font-size:12px}
 #qrcode{background:#fff;display:inline-block;padding:10px;border-radius:12px;border:1px solid var(--border)}
 .status{margin-top:8px;color:var(--muted);font-size:14px}


### PR DESCRIPTION
Refs #12.

Implements provider-agnostic paywall UX hardening:
- Clear intro copy + status/help lines
- Invoice create failure shown inline (no alert)
- Copy invoice, refresh status, reload
- New invoice/regenerate flow
- Invoice expiry messaging
- Detect likely cookie-blocked unlock (paid confirmed but still paywalled after reload) and guide user

No provider names in UI copy; designed to work with future providers by mapping failures into the same states.