### PR TITLE
docs: authoring + config + templates (refs #10 #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,26 @@ docker compose up --build
 
 ## Writing posts
 
-Create `content/posts/my-post.md`:
+Posts live in `content/posts/*.md`.
+
+### Quick start
+
+Copy a template:
+
+- `templates/post.free.md`
+- `templates/post.paywalled.md`
+
+Then save it as `content/posts/<slug>.md` (the slug is the filename).
+
+### Frontmatter (v0.1)
+
+Supported keys:
+- `title`
+- `date`
+- `price_sats` (paywalled when `> 0`)
+- `description` (optional)
+
+Example:
 
 ```md
 ---
@@ -95,6 +114,14 @@ This is the full post.
 ```
 
 `price_sats: 0` makes a post free.
+
+More details: **[`docs/authoring.md`](docs/authoring.md)**.
+
+## Docs
+
+- Authoring: `docs/authoring.md`
+- Configuration: `docs/configuration.md`
+- Deploy: `docs/deploy.md`
 
 ## Deployment notes
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -1,0 +1,71 @@
+# Authoring (v0.1)
+
+Paywritr is a flat-file Markdown blog.
+
+- Posts live in: `content/posts/*.md`
+- The **slug is the filename** (without `.md`). Example: `content/posts/hello.md` → `/post/hello`
+- A post is **paywalled** when `price_sats > 0`.
+- **Unlocks are per device/browser** (stored as a signed `HttpOnly` cookie per post slug).
+
+## Frontmatter schema (v0.1)
+
+Supported keys:
+
+- `title` (string, recommended)
+- `date` (string, optional; displayed as-is)
+- `price_sats` (number, optional; `0` or missing means free)
+- `description` (string, optional; shown on homepage)
+
+Example (free post):
+
+```md
+---
+title: Hello, Paywritr
+date: 2026-02-16
+price_sats: 0
+description: A free post.
+---
+
+This is a free post.
+```
+
+Example (paywalled post):
+
+```md
+---
+title: My Premium Note
+date: 2026-02-16
+price_sats: 500
+description: A paywalled post.
+---
+
+This paragraph is the teaser.
+
+<!--more-->
+
+## Paid section
+
+This content is only shown after payment + unlock.
+```
+
+## Teaser / preview rules
+
+Paywritr uses a preview split marker:
+
+- **Teaser** = content *before* `<!--more-->`
+- **Full content** = the entire Markdown body
+
+Important behavior (anti-leak):
+- If `price_sats > 0` and the author forgets `<!--more-->`, Paywritr **does not** show the full post.
+- Instead, it shows a conservative fallback teaser (first ~800 characters).
+
+## Slug & unlock cookie behavior
+
+- Unlock cookie name is derived from the slug: `unlock_<slug>`.
+- Changing the filename (slug) creates a **new** unlock scope. Readers who unlocked the old slug will not be unlocked for the new one.
+
+## Common gotchas
+
+- **Price units are sats** (`price_sats`).
+- Use `<!--more-->` in paywalled posts to control the teaser.
+- If a reader pays but still sees the paywall after reload, it’s usually because their browser is **blocking cookies** for the site.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,44 @@
+# Configuration (v0.1)
+
+Paywritr is configured via environment variables.
+
+## Required
+
+- `APP_SECRET`
+  - Long random string.
+  - Used to sign unlock cookies and short-lived invoice polling state tokens.
+
+## Server
+
+- `PORT` (default: `3000`)
+- `BASE_URL` (default: `http://localhost:<PORT>`)
+- `SITE_TITLE` (default: `Paywritr`)
+- `UNLOCK_DAYS` (default: `30`)
+- `COOKIE_SECURE` (default: `false`)
+  - Set `true` in production behind HTTPS so cookies are marked `Secure`.
+
+## Payments provider (v0.1)
+
+v0.1 ships with **Alby Hub only**.
+
+- `PAYMENTS_PROVIDER=alby_hub`
+- `ALBY_HUB_URL`
+  - A `nostr+walletconnect://...` URI that includes a secret.
+  - Treat it like a password: **do not commit it**.
+
+> LNbits is intentionally deferred to a later build.
+
+## Example .env
+
+```bash
+PORT=3000
+BASE_URL=http://localhost:3000
+SITE_TITLE=Paywritr
+
+APP_SECRET=change-me-to-a-long-random-string
+UNLOCK_DAYS=30
+COOKIE_SECURE=false
+
+PAYMENTS_PROVIDER=alby_hub
+ALBY_HUB_URL='nostr+walletconnect://...'
+```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,26 @@
+# Deploy (v0.1)
+
+Paywritr is a small Node server. You can run it directly with `npm start` or via Docker.
+
+## Production requirements
+
+- **HTTPS** is strongly recommended.
+  - Set `COOKIE_SECURE=true` so unlock cookies are marked `Secure`.
+
+## Environment variables
+
+See `docs/configuration.md`.
+
+At minimum, set:
+- `APP_SECRET` (required)
+- `PAYMENTS_PROVIDER=alby_hub`
+- `ALBY_HUB_URL` (secret)
+- `BASE_URL` (should be your public URL)
+- `COOKIE_SECURE=true` (when behind HTTPS)
+
+## Docker
+
+`docker-compose.yml` is provided for local or server deployments.
+
+- Keep `.env` local (not committed).
+- Content is mounted read-only from `./content`.

--- a/templates/post.free.md
+++ b/templates/post.free.md
@@ -1,0 +1,8 @@
+---
+title: "New Post Title"
+date: "2026-02-16"
+price_sats: 0
+description: "Optional short description for the homepage."
+---
+
+Write your post here.

--- a/templates/post.paywalled.md
+++ b/templates/post.paywalled.md
@@ -1,0 +1,14 @@
+---
+title: "New Premium Post"
+date: "2026-02-16"
+price_sats: 500
+description: "Optional short description for the homepage."
+---
+
+This paragraph is the teaser.
+
+<!--more-->
+
+## Paid content starts here
+
+Only visible after invoice is paid and the unlock cookie is set.


### PR DESCRIPTION
Refs #10 and #11.

Adds v0.1 docs and templates aligned to the current build:
- README updates (writing posts + links to docs)
- docs/authoring.md (frontmatter + slug rules + <!--more--> teaser + anti-leak fallback)
- docs/configuration.md (env var reference; Alby Hub only; LNbits deferred)
- docs/deploy.md (minimal deploy notes)
- templates for free + paywalled posts

No provider names in reader UX; docs clearly state: Alby Hub only, no accounts, unlock via signed HttpOnly cookie.