### PR TITLE
docs: park server-side entitlements spec

### DIFF
--- a/docs/MVP_v0.2.md
+++ b/docs/MVP_v0.2.md
@@ -18,20 +18,19 @@ This document defines what a *real MVP* for Paywritr should include **beyond** t
 ## Prioritized requirements (grouped)
 
 ### Reliability (P0 unless noted)
-1. **(P0) Payment state persistence (server-side entitlements)**
-   - Add a minimal server-side record of invoice/payment → post entitlement.
-   - Cookie becomes a convenience, not the sole source of truth.
 
-2. **(P0) Webhook/idempotency handling for payment confirmation**
+> Note: Server-side entitlements persistence is intentionally **parked** (see `docs/PARKING_LOT.md`) to keep MVP flat.
+
+1. **(P0) Webhook/idempotency handling for payment confirmation**
    - Safe retries; no double-unlocks; no stuck “paid but locked.”
 
-3. **(P0) Structured logging + request correlation for pay/unlock flow**
-   - Minimal logs around invoice create, payment confirm, entitlement issue, and content serve.
+2. **(P0) Structured logging + request correlation for pay/unlock flow**
+   - Minimal logs around invoice create, payment confirm, and content serve.
 
-4. **(P0) Robust upstream failure handling**
+3. **(P0) Robust upstream failure handling**
    - Gracefully handle provider downtime/timeouts with clear user messaging + safe retry paths.
 
-5. **(P1) Diagnostics endpoints**
+4. **(P1) Diagnostics endpoints**
    - Keep `/healthz` and optionally add `/readyz` if needed for deployments.
 
 ### Admin / authoring

--- a/docs/PARKING_LOT.md
+++ b/docs/PARKING_LOT.md
@@ -1,0 +1,26 @@
+# Parking Lot (Spec Notes)
+
+This document is a place to capture **possible future features** and design directions that we explicitly do **not** want to commit to as MVP requirements yet.
+
+The goal is to keep Paywritr **flat** (simple, low operational overhead) while still recording ideas we might revisit after 1.0.
+
+---
+
+## Server-side entitlements (invoice/payment persistence)
+
+**Idea:** Store a minimal server-side record mapping `invoice/payment → post entitlement` so that the unlock cookie becomes a convenience, not the source of truth.
+
+**Why it’s attractive**
+- Helps with “paid but locked” recovery.
+- Enables cross-device restore (if we ever want it).
+- Enables better publisher confidence (sales/entitlements view).
+
+**Why it’s NOT in the flat MVP**
+- Introduces durable server-side state (DB/KV) and migrations/backup concerns.
+- Moves Paywritr toward account/identity-like behavior (even if we avoid usernames).
+- Adds operational/debug surface area (webhooks, reconciliation, data retention).
+
+**If we revisit later**
+- Keep the author/reader UX provider-agnostic.
+- Prefer minimal storage (SQLite/KV) and strong idempotency.
+- Define explicit data retention + privacy expectations.


### PR DESCRIPTION
Moves the server-side entitlements persistence idea out of the MVP v0.2 requirements into a parking-lot spec doc (docs/PARKING_LOT.md) to keep the project explicitly flat.