### PR TITLE
perf: speed up Alby Hub polling (refs #30)

### DIFF
--- a/lib/payments.js
+++ b/lib/payments.js
@@ -123,8 +123,11 @@ function classifyRelayFailure(e) {
   return { kind: 'relay_error', message: stringifyError(e) || 'relay error' };
 }
 
+// Reuse a single pool across calls to avoid reconnect overhead during polling.
+const _albyHubPool = createAlbyHubPool();
+
 async function albyHubCall({ relays, walletPubkey, clientSecretKey, method, params, timeoutMs = 30_000 }) {
-  const pool = createAlbyHubPool();
+  const pool = _albyHubPool;
   const targetRelays = Array.isArray(relays) && relays.length ? relays : [];
   const clientPubkey = getPublicKey(clientSecretKey);
   const created_at = Math.floor(Date.now() / 1000);
@@ -178,9 +181,8 @@ async function albyHubCall({ relays, walletPubkey, clientSecretKey, method, para
       try {
         sub?.close?.();
       } catch {}
-      try {
-        pool.close(targetRelays);
-      } catch {}
+      // Intentionally do not close the shared pool here.
+      // The server is long-lived and polling benefits from keeping relay connections warm.
     };
 
     const t = setTimeout(() => {
@@ -327,6 +329,8 @@ export async function checkInvoicePaid({ provider, payment_hash }) {
       clientSecretKey: secretKey,
       method: 'lookup_invoice',
       params: { payment_hash },
+      // Polling should fail fast; long timeouts can make the UI feel stuck.
+      timeoutMs: 7_000,
     });
 
     if (msg?.error) {


### PR DESCRIPTION
Refs #30.

Speeds up paid/unlock detection by:
- Reusing a shared Nostr pool (keeps relay connections warm)
- Reducing `lookup_invoice` timeout to 7s so polling fails fast instead of blocking the UI for ~30s per attempt

Net effect: fewer long hangs and faster perceived unlock after payment.