### PR TITLE
perf: tune Alby Hub lookup timeout to 5s (refs #32)

### DIFF
--- a/lib/payments.js
+++ b/lib/payments.js
@@ -330,7 +330,8 @@ export async function checkInvoicePaid({ provider, payment_hash }) {
       method: 'lookup_invoice',
       params: { payment_hash },
       // Polling should fail fast; long timeouts can make the UI feel stuck.
-      timeoutMs: 7_000,
+      // Tuned based on observed real-world unlock latency.
+      timeoutMs: 5_000,
     });
 
     if (msg?.error) {


### PR DESCRIPTION
Refs #32.

Tuned Alby Hub `lookup_invoice` timeout from 7s -> 5s based on observed unlock behavior during PoC testing.