### PR TITLE
perf: tune Alby Hub lookup timeout to 10s (refs #32)

### DIFF
--- a/lib/payments.js
+++ b/lib/payments.js
@@ -331,7 +331,7 @@ export async function checkInvoicePaid({ provider, payment_hash }) {
       params: { payment_hash },
       // Polling should fail fast; long timeouts can make the UI feel stuck.
       // Tuned based on observed real-world unlock latency.
-      timeoutMs: 5_000,
+      timeoutMs: 10_000,
     });
 
     if (msg?.error) {


### PR DESCRIPTION
Refs #32.

Raises Alby Hub `lookup_invoice` timeout from 5s -> 10s to reduce timeout/retry spikes (observed 20s+ unlock times) while staying well below the old 30s hang.