### PR TITLE
docs: design token contract (refs #67)

### DIFF
--- a/docs/design_tokens.md
+++ b/docs/design_tokens.md
@@ -1,0 +1,54 @@
+# Design tokens (v0.2)
+
+Paywritr uses **CSS variables (design tokens)** as a stable styling contract.
+
+Principles:
+- **Semantic tokens** (meaning-based) over raw values.
+- Base/component CSS must reference **tokens only** (no hard-coded colors in rules).
+- Themes override tokens to change the look without rewriting component CSS.
+
+This file defines the canonical token set.
+
+## Color tokens
+These are the minimum semantic colors used across the UI.
+
+- `--color-bg` — page background
+- `--color-surface` — elevated surface background (cards, panels)
+- `--color-surface-2` — secondary surface background (subtle panels)
+- `--color-text` — primary text
+- `--color-muted` — muted/secondary text
+- `--color-border` — separators/borders
+- `--color-accent` — links / primary accent
+- `--color-accent-contrast` — text on accent background
+
+Optional (add only when needed):
+- `--color-success`, `--color-warning`, `--color-danger`
+
+## Typography tokens
+- `--font-body` — body font stack
+- `--font-mono` — monospace font stack
+- `--font-size-base` — base font size (e.g. `16px`)
+- `--line-height-base` — base line-height (e.g. `1.7`)
+
+## Spacing + shape tokens
+Small consistent scale is preferred.
+
+- `--space-1` … `--space-8` — spacing scale
+- `--radius-1` … `--radius-4` — radius scale
+
+## Layout tokens
+- `--content-max-width` — max width of `.container`
+
+## Light/Dark mode convention
+Tokens MUST support both schemes:
+- Light values at `:root`
+- Dark overrides under `[data-color-scheme="dark"]`
+
+The toggle/persistence mechanism is tracked separately (#70 chain).
+
+## Usage rules
+- Component CSS should use tokens, e.g.:
+  - `color: var(--color-text);`
+  - `background: var(--color-bg);`
+  - `border-color: var(--color-border);`
+- Avoid hard-coded hex values in rules; if a new color is required, introduce a token.

--- a/static/style.css
+++ b/static/style.css
@@ -1,10 +1,55 @@
 :root{
-  --bg:#fff;
-  --fg:#111;
-  --muted:#666;
-  --border:#e9e9e9;
-  --max:720px;
+  /* ---- Design tokens (semantic) ---- */
+  --color-bg:#fff;
+  --color-surface:#fff;
+  --color-surface-2:#fafafa;
+  --color-text:#111;
+  --color-muted:#666;
+  --color-border:#e9e9e9;
+  --color-accent:#111;
+  --color-accent-contrast:#fff;
+
+  --font-body:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+  --font-mono:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+  --font-size-base:16px;
+  --line-height-base:1.7;
+
+  --space-1:4px;
+  --space-2:8px;
+  --space-3:12px;
+  --space-4:16px;
+  --space-5:20px;
+  --space-6:24px;
+  --space-7:32px;
+  --space-8:48px;
+
+  --radius-1:8px;
+  --radius-2:10px;
+  --radius-3:14px;
+  --radius-4:999px;
+
+  --content-max-width:720px;
+
+  /* ---- Back-compat aliases (will be removed after #68 refactor) ---- */
+  --bg:var(--color-bg);
+  --fg:var(--color-text);
+  --muted:var(--color-muted);
+  --border:var(--color-border);
+  --max:var(--content-max-width);
 }
+
+/* Optional future scheme overrides (enabled once [data-color-scheme] is applied) */
+[data-color-scheme="dark"]{
+  --color-bg:#0f0f10;
+  --color-surface:#171719;
+  --color-surface-2:#1e1e21;
+  --color-text:#f2f2f0;
+  --color-muted:#a5a19a;
+  --color-border:rgba(242,242,240,0.12);
+  --color-accent:#f2f2f0;
+  --color-accent-contrast:#0f0f10;
+}
+
 *{box-sizing:border-box}
 html,body{height:100%}
 body{


### PR DESCRIPTION
Refs #67.

Adds an explicit design token contract (`docs/design_tokens.md`) and introduces semantic token variables in `static/style.css` (with temporary back-compat aliases for existing CSS).

Includes a methodical local smoke test (home + free post + paywalled post + temp page route) and `npm test`.

Next: #68 will refactor all component rules to use the semantic tokens directly and remove reliance on legacy aliases.