### PR TITLE
feat: theme filesystem + THEME=classic + pages nav (refs #66)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,14 @@ Paywritr is configured via environment variables.
 
 v0.2 currently ships with **Alby Hub only**.
 
+## Theme selection
+
+Themes live in the `themes/` folder. Any subdirectory under `themes/` is considered an available theme.
+
+Select the active theme by setting:
+
+- `THEME=classic` (default)
+
 - `PAYMENTS_PROVIDER=alby_hub`
 - `ALBY_HUB_URL`
   - A `nostr+walletconnect://...` URI that includes a secret.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import express from 'express';
 import cookieParser from 'cookie-parser';
 import { marked } from 'marked';
+import fs from 'node:fs/promises';
 
 import { parsePaymentsProvider, createInvoice, checkInvoicePaid } from './lib/payments.js';
 import { scanContent, findCanonical, ContentValidationError } from './lib/content.js';
@@ -14,6 +15,9 @@ const SITE_TITLE = process.env.SITE_TITLE || 'PayBlog';
 const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
 
 const PAYMENTS_PROVIDER = parsePaymentsProvider(process.env);
+
+const THEME = (process.env.THEME || 'classic').trim();
+const THEMES_DIR = path.join(process.cwd(), 'themes');
 
 const APP_SECRET = process.env.APP_SECRET || '';
 const UNLOCK_DAYS = Number(process.env.UNLOCK_DAYS || 30);
@@ -32,6 +36,7 @@ app.set('trust proxy', 1);
 app.use(express.json({ limit: '64kb' }));
 app.use(cookieParser());
 app.use('/static', express.static(path.join(process.cwd(), 'static'), { fallthrough: false }));
+app.use('/themes', express.static(THEMES_DIR, { fallthrough: false }));
 
 function asyncHandler(fn) {
   return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
@@ -145,6 +150,37 @@ async function listPosts() {
     }));
 }
 
+async function listPages() {
+  const { pages } = await scanContent();
+  // Drafts excluded.
+  return pages
+    .filter((p) => !p.draft)
+    .slice()
+    .sort((a, b) => String(a.title || '').localeCompare(String(b.title || '')))
+    .map((p) => ({
+      slug: p.slug,
+      title: p.title,
+    }));
+}
+
+async function resolveThemeCssHref() {
+  // Any subdirectory in /themes is a valid theme; THEME selects the active one.
+  // Folder name is the canonical identifier.
+  const candidates = [THEME, 'classic'];
+  for (const t of candidates) {
+    if (!t) continue;
+    const rel = path.posix.join('/themes', encodeURIComponent(t), 'theme.css');
+    const abs = path.join(THEMES_DIR, t, 'theme.css');
+    try {
+      await fs.stat(abs);
+      return rel;
+    } catch {
+      // try next
+    }
+  }
+  return null;
+}
+
 async function resolveContent({ type, slug, allowAlias = false }) {
   assertValidSlug(slug);
 
@@ -232,7 +268,15 @@ function escapeHtml(s) {
     .replaceAll("'", '&#39;');
 }
 
-function layout({ title, content, extraHead = '', extraBody = '' }) {
+async function layout({ title, content, extraHead = '', extraBody = '' }) {
+  const themeHref = await resolveThemeCssHref();
+  const pages = await listPages();
+  const nav = pages.length
+    ? `<nav class="site-nav" aria-label="Pages">${pages
+        .map((p) => `<a class="nav-link" href="/${encodeURIComponent(p.slug)}/">${escapeHtml(p.title)}</a>`)
+        .join('')}</nav>`
+    : '';
+
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -240,12 +284,16 @@ function layout({ title, content, extraHead = '', extraBody = '' }) {
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${escapeHtml(title)} — ${escapeHtml(SITE_TITLE)}</title>
   <link rel="stylesheet" href="/static/style.css" />
+  ${themeHref ? `<link rel="stylesheet" href="${themeHref}" />` : ''}
   ${extraHead}
 </head>
 <body>
   <header class="site-header">
     <div class="container">
-      <a class="brand" href="/">${escapeHtml(SITE_TITLE)}</a>
+      <div class="site-header-row">
+        <a class="brand" href="/">${escapeHtml(SITE_TITLE)}</a>
+      </div>
+      ${nav}
     </div>
   </header>
 
@@ -280,7 +328,7 @@ app.get(
       .join('\n');
 
     res.type('html').send(
-      layout({
+      await layout({
         title: 'Home',
         content: `
       <section class="hero">
@@ -373,14 +421,14 @@ app.get(
     } catch (e) {
       if (e instanceof ContentValidationError) {
         res.status(500).type('html').send(
-          layout({
+          await layout({
             title: 'Content error',
             content: `<h1>Content error</h1><p class="muted">${escapeHtml(e.message)}</p>`,
           })
         );
         return;
       }
-      res.status(404).type('html').send(layout({ title: 'Not found', content: '<h1>Not found</h1>' }));
+      res.status(404).type('html').send(await layout({ title: 'Not found', content: '<h1>Not found</h1>' }));
       return;
     }
 
@@ -409,7 +457,7 @@ app.get(
     const slug = resolved.canonicalSlug;
 
     res.type('html').send(
-      layout({
+      await layout({
         title: post.title,
         content: renderPostHtml({ post, slug, req }),
         extraBody: `<script src="/static/qrcode.min.js"></script><script src="/static/pay.js"></script>`,
@@ -533,7 +581,7 @@ app.get(
     // Avoid route collisions with known prefixes.
     const reserved = new Set(['p', 'post', 'api', 'static', 'healthz', 'readyz']);
     if (reserved.has(String(slug || '').toLowerCase())) {
-      res.status(404).type('html').send(layout({ title: 'Not found', content: '<h1>Not found</h1>' }));
+      res.status(404).type('html').send(await layout({ title: 'Not found', content: '<h1>Not found</h1>' }));
       return;
     }
 
@@ -543,14 +591,14 @@ app.get(
     } catch (e) {
       if (e instanceof ContentValidationError) {
         res.status(500).type('html').send(
-          layout({
+          await layout({
             title: 'Content error',
             content: `<h1>Content error</h1><p class="muted">${escapeHtml(e.message)}</p>`,
           })
         );
         return;
       }
-      res.status(404).type('html').send(layout({ title: 'Not found', content: '<h1>Not found</h1>' }));
+      res.status(404).type('html').send(await layout({ title: 'Not found', content: '<h1>Not found</h1>' }));
       return;
     }
 
@@ -562,7 +610,7 @@ app.get(
     const page = resolved.page;
 
     res.type('html').send(
-      layout({
+      await layout({
         title: page.title,
         content: renderPageHtml({ page }),
       })
@@ -572,7 +620,7 @@ app.get(
 
 // Basic error handler to avoid unhandled promise rejections leaking stack traces.
 // (Express 5 will route async errors here.)
-app.use((err, req, res, next) => {
+app.use(async (err, req, res, next) => {
   const status = Number(err?.statusCode || err?.status || 500);
   const msg = status >= 500 ? 'internal error' : String(err?.message || 'error');
 
@@ -581,7 +629,7 @@ app.use((err, req, res, next) => {
     return;
   }
 
-  res.status(status).type('html').send(layout({ title: 'Error', content: `<h1>${escapeHtml(msg)}</h1>` }));
+  res.status(status).type('html').send(await layout({ title: 'Error', content: `<h1>${escapeHtml(msg)}</h1>` }));
 });
 
 app.listen(PORT, () => {

--- a/static/style.css
+++ b/static/style.css
@@ -55,7 +55,11 @@ a{color:var(--color-accent);text-decoration-thickness:1px;text-underline-offset:
 a:hover{opacity:.85}
 .container{max-width:var(--content-max-width);margin:0 auto;padding:0 var(--space-5)}
 .site-header{padding:var(--space-6) 0;border-bottom:1px solid var(--color-border)}
+.site-header-row{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4)}
 .brand{font-weight:600;letter-spacing:.2px;text-decoration:none;color:inherit}
+.site-nav{display:flex;flex-wrap:wrap;gap:var(--space-4);margin-top:var(--space-3)}
+.nav-link{color:var(--color-muted);text-decoration:none}
+.nav-link:hover{text-decoration:underline;color:var(--color-text)}
 .hero{padding:var(--space-7) 0 var(--space-3)}
 .hero h1{font-size:28px;line-height:1.2;margin:0 0 6px}
 .muted{color:var(--color-muted)}

--- a/themes/classic/theme.css
+++ b/themes/classic/theme.css
@@ -1,0 +1,30 @@
+/* Paywritr theme: classic
+   Identifier is the directory name: themes/classic/
+
+   This file defines token values for both schemes.
+   Component/layout rules live in /static/style.css.
+*/
+
+:root{
+  --color-bg:#fff;
+  --color-surface:#fff;
+  --color-surface-2:#fafafa;
+  --color-text:#111;
+  --color-muted:#666;
+  --color-border:#e9e9e9;
+  --color-accent:#111;
+  --color-accent-contrast:#fff;
+
+  --content-max-width:720px;
+}
+
+[data-color-scheme="dark"]{
+  --color-bg:#0f0f10;
+  --color-surface:#171719;
+  --color-surface-2:#1e1e21;
+  --color-text:#f2f2f0;
+  --color-muted:#a5a19a;
+  --color-border:rgba(242,242,240,0.12);
+  --color-accent:#f2f2f0;
+  --color-accent-contrast:#0f0f10;
+}

--- a/themes/classic/theme.json
+++ b/themes/classic/theme.json
@@ -1,0 +1,5 @@
+{
+  "label": "Classic",
+  "version": "0.1.0",
+  "notes": "Default theme. Identifier is the folder name: classic."
+}


### PR DESCRIPTION
Refs #66.

Implements theme filesystem wiring:
- Adds `themes/classic/theme.css` (classic default) + optional `theme.json` metadata
- Serves `/themes/*` statics and links active theme CSS in layout
- `THEME=<folder>` selects active theme; missing themes fallback to `classic`

Also:
- Layout now auto-lists `type: page` content items as top-level nav links (no reader theme picker; aligns with spec)
- Adds minimal nav CSS (`.site-nav`, `.nav-link`)
- Docs: `THEME` described in `docs/configuration.md`

Smoke tests (bounty local):
- `npm test` ✅
- Server run (PORT=3015, THEME=classic): theme.css served, HTML links theme, page nav appears, `/about/` works ✅
- Server run (PORT=3016, THEME=missing): HTML falls back to classic theme link ✅