### PR TITLE
feat: color scheme attribute plumbing (refs #73)

### DIFF
--- a/docs/design_tokens.md
+++ b/docs/design_tokens.md
@@ -20,6 +20,7 @@ These are the minimum semantic colors used across the UI.
 - `--color-border` — separators/borders
 - `--color-accent` — links / primary accent
 - `--color-accent-contrast` — text on accent background
+- `--color-qr-bg` — QR code container background (keep high contrast / usually white)
 
 Optional (add only when needed):
 - `--color-success`, `--color-warning`, `--color-danger`

--- a/server.js
+++ b/server.js
@@ -278,11 +278,22 @@ async function layout({ title, content, extraHead = '', extraBody = '' }) {
     : '';
 
   return `<!doctype html>
-<html lang="en">
+<html lang="en" data-color-scheme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${escapeHtml(title)} — ${escapeHtml(SITE_TITLE)}</title>
+
+  <script>
+    // #73: scheme plumbing. Default to system preference (cookie override/persistence in #72).
+    (function () {
+      try {
+        var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+        if (m && m.matches) document.documentElement.setAttribute('data-color-scheme', 'dark');
+      } catch (e) {}
+    })();
+  </script>
+
   <link rel="stylesheet" href="/static/style.css" />
   ${themeHref ? `<link rel="stylesheet" href="${themeHref}" />` : ''}
   ${extraHead}

--- a/static/style.css
+++ b/static/style.css
@@ -8,6 +8,7 @@
   --color-border:#e9e9e9;
   --color-accent:#111;
   --color-accent-contrast:#fff;
+  --color-qr-bg:#fff; /* ensure QR code remains readable in dark scheme */
 
   --font-body:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
   --font-mono:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
@@ -41,6 +42,7 @@
   --color-border:rgba(242,242,240,0.12);
   --color-accent:#f2f2f0;
   --color-accent-contrast:#0f0f10;
+  --color-qr-bg:#fff; /* keep QR background white for contrast */
 }
 
 *{box-sizing:border-box}
@@ -88,6 +90,6 @@ a:hover{opacity:.85}
 .invoice-row{margin-bottom:12px}
 .invoice-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}
 .bolt11{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;background:var(--color-surface);border:1px solid var(--color-border);padding:10px;border-radius:var(--radius-2);font-size:12px}
-#qrcode{background:var(--color-surface);display:inline-block;padding:10px;border-radius:12px;border:1px solid var(--color-border)}
+#qrcode{background:var(--color-qr-bg);display:inline-block;padding:10px;border-radius:12px;border:1px solid var(--color-border)}
 .status{margin-top:8px;color:var(--color-muted);font-size:14px}
 .site-footer{padding:var(--space-6) 0;border-top:1px solid var(--color-border);color:var(--color-muted);font-size:13px}

--- a/themes/classic/theme.css
+++ b/themes/classic/theme.css
@@ -14,6 +14,7 @@
   --color-border:#e9e9e9;
   --color-accent:#111;
   --color-accent-contrast:#fff;
+  --color-qr-bg:#fff;
 
   --content-max-width:720px;
 }
@@ -27,4 +28,5 @@
   --color-border:rgba(242,242,240,0.12);
   --color-accent:#f2f2f0;
   --color-accent-contrast:#0f0f10;
+  --color-qr-bg:#fff;
 }


### PR DESCRIPTION
Refs #73.

Implements scheme plumbing:
- Adds `data-color-scheme="light"` default on `<html>`
- Adds early inline script to switch to dark when system preference is dark (`prefers-color-scheme: dark`)
- Adds `--color-qr-bg` token and uses it for QR container background to keep QR readable

Notes:
- Cookie override/persistence is tracked in #72 (this commit does not read/set cookies).

Smoke tests (bounty local):
- `npm test` ✅
- Server run (PORT=3017): HTML includes scheme attr + scheme script ✅
- Hex-color guard remains clean ✅