### PR TITLE
feat: color scheme cookie persistence (refs #72)

### DIFF
--- a/server.js
+++ b/server.js
@@ -285,9 +285,24 @@ async function layout({ title, content, extraHead = '', extraBody = '' }) {
   <title>${escapeHtml(title)} — ${escapeHtml(SITE_TITLE)}</title>
 
   <script>
-    // #73: scheme plumbing. Default to system preference (cookie override/persistence in #72).
+    // #72: persist scheme in cookie; if absent, default to system preference.
     (function () {
+      function getCookie(name) {
+        try {
+          var m = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/[-.$?*|{}()\[\]\\/+^]/g, '\\$&') + '=([^;]*)'));
+          return m ? decodeURIComponent(m[1]) : '';
+        } catch (e) {
+          return '';
+        }
+      }
+
       try {
+        var v = (getCookie('paywritr_color_scheme') || '').toLowerCase();
+        if (v === 'light' || v === 'dark') {
+          document.documentElement.setAttribute('data-color-scheme', v);
+          return;
+        }
+
         var m = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
         if (m && m.matches) document.documentElement.setAttribute('data-color-scheme', 'dark');
       } catch (e) {}


### PR DESCRIPTION
Refs #72.

Updates the early scheme script to read `paywritr_color_scheme=light|dark` from cookies; if absent/invalid it falls back to system preference (`prefers-color-scheme`).

Notes:
- This PR only **reads** the cookie. Writing the cookie happens in #71 (toggle UI) or a later server helper if we add one.

Smoke tests (bounty local):
- `npm test` ✅
- Server run (PORT=3018): HTML includes cookie read logic and default attr ✅