### PR TITLE
feat: global light/dark toggle UI (refs #71)

### DIFF
--- a/server.js
+++ b/server.js
@@ -318,6 +318,7 @@ async function layout({ title, content, extraHead = '', extraBody = '' }) {
     <div class="container">
       <div class="site-header-row">
         <a class="brand" href="/">${escapeHtml(SITE_TITLE)}</a>
+        <button id="schemeToggle" class="scheme-toggle" type="button" aria-label="Toggle light/dark mode" aria-pressed="false">Light</button>
       </div>
       ${nav}
     </div>
@@ -334,6 +335,7 @@ async function layout({ title, content, extraHead = '', extraBody = '' }) {
   </footer>
 
   ${extraBody}
+  <script src="/static/scheme-toggle.js"></script>
 </body>
 </html>`;
 }

--- a/static/scheme-toggle.js
+++ b/static/scheme-toggle.js
@@ -1,0 +1,35 @@
+(function () {
+  const btn = document.getElementById('schemeToggle');
+  if (!btn) return;
+
+  const COOKIE_NAME = 'paywritr_color_scheme';
+  const MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
+
+  function currentScheme() {
+    const v = String(document.documentElement.getAttribute('data-color-scheme') || '').toLowerCase();
+    return v === 'dark' ? 'dark' : 'light';
+  }
+
+  function setScheme(scheme) {
+    const v = scheme === 'dark' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-color-scheme', v);
+    try {
+      document.cookie = `${COOKIE_NAME}=${encodeURIComponent(v)}; Max-Age=${MAX_AGE_SECONDS}; Path=/; SameSite=Lax`;
+    } catch {}
+  }
+
+  function render() {
+    const v = currentScheme();
+    btn.textContent = v === 'dark' ? 'Dark' : 'Light';
+    btn.setAttribute('aria-pressed', v === 'dark' ? 'true' : 'false');
+  }
+
+  btn.addEventListener('click', () => {
+    const next = currentScheme() === 'dark' ? 'light' : 'dark';
+    setScheme(next);
+    render();
+  });
+
+  // Initial render based on the scheme chosen by the early head script (#72/#73).
+  render();
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -62,6 +62,9 @@ a:hover{opacity:.85}
 .site-nav{display:flex;flex-wrap:wrap;gap:var(--space-4);margin-top:var(--space-3)}
 .nav-link{color:var(--color-muted);text-decoration:none}
 .nav-link:hover{text-decoration:underline;color:var(--color-text)}
+.scheme-toggle{appearance:none;border:1px solid var(--color-border);background:var(--color-surface);color:var(--color-muted);border-radius:var(--radius-4);padding:8px 12px;font:inherit;font-size:13px;cursor:pointer}
+.scheme-toggle:hover{color:var(--color-text)}
+.scheme-toggle:focus-visible{outline:2px solid var(--color-accent);outline-offset:2px}
 .hero{padding:var(--space-7) 0 var(--space-3)}
 .hero h1{font-size:28px;line-height:1.2;margin:0 0 6px}
 .muted{color:var(--color-muted)}


### PR DESCRIPTION
Refs #71.

Adds a global Light/Dark toggle in the header that:
- updates `data-color-scheme` immediately
- writes the `paywritr_color_scheme=light|dark` cookie (read logic already in #72)
- is present on every reader route including paywalled/locked post view

Implementation:
- Adds `static/scheme-toggle.js` and includes it globally
- Adds minimal `.scheme-toggle` styling

Smoke tests (bounty local):
- `npm test` ✅
- Server run (PORT=3019): toggle + script present on `/`, `/p/free-note/`, `/p/hello-paywall/` (paywall locked state) ✅
- Asset served: `/static/scheme-toggle.js` ✅
- Hex-color guard remains clean ✅