### PR TITLE
feat: classic theme polish (refs #76)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,10 @@
+/* Base app CSS (layout + components).
+   Token values are provided by the active theme: /themes/<theme>/theme.css.
+
+   Fallback defaults in this file are intentionally minimal.
+*/
+
 :root{
-  /* ---- Design tokens (semantic) ---- */
   --color-bg:#fff;
   --color-surface:#fff;
   --color-surface-2:#fafafa;
@@ -8,7 +13,7 @@
   --color-border:#e9e9e9;
   --color-accent:#111;
   --color-accent-contrast:#fff;
-  --color-qr-bg:#fff; /* ensure QR code remains readable in dark scheme */
+  --color-qr-bg:#fff;
 
   --font-body:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
   --font-mono:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
@@ -32,7 +37,6 @@
   --content-max-width:720px;
 }
 
-/* Scheme token overrides (wired up in #73) */
 [data-color-scheme="dark"]{
   --color-bg:#0f0f10;
   --color-surface:#171719;
@@ -42,7 +46,7 @@
   --color-border:rgba(242,242,240,0.12);
   --color-accent:#f2f2f0;
   --color-accent-contrast:#0f0f10;
-  --color-qr-bg:#fff; /* keep QR background white for contrast */
+  --color-qr-bg:#fff;
 }
 
 *{box-sizing:border-box}
@@ -65,23 +69,42 @@ a:hover{opacity:.85}
 .scheme-toggle{appearance:none;border:1px solid var(--color-border);background:var(--color-surface);color:var(--color-muted);border-radius:var(--radius-4);padding:8px 12px;font:inherit;font-size:13px;cursor:pointer}
 .scheme-toggle:hover{color:var(--color-text)}
 .scheme-toggle:focus-visible{outline:2px solid var(--color-accent);outline-offset:2px}
-.hero{padding:var(--space-7) 0 var(--space-3)}
-.hero h1{font-size:28px;line-height:1.2;margin:0 0 6px}
+
+.hero{padding:var(--space-8) 0 var(--space-5)}
+.hero h1{font-size:44px;line-height:1.05;letter-spacing:-0.02em;margin:0 0 var(--space-2);text-align:center}
+.hero .muted{text-align:center;max-width:44ch;margin:0 auto}
+
 .muted{color:var(--color-muted)}
+
 .post-list{padding:var(--space-5) 0 60px}
-.post-card{padding:var(--space-5) 0;border-bottom:1px solid var(--color-border)}
-.post-card h2{font-size:18px;margin:0 0 6px;font-weight:600}
+.post-card{padding:var(--space-4) 0}
+.post-card + .post-card{border-top:1px solid var(--color-border)}
+.post-card h2{font-size:18px;margin:0;font-weight:600;line-height:1.3}
+.post-card .meta{margin-top:var(--space-1)}
 .meta{font-size:13px;color:var(--color-muted)}
-.desc{margin:10px 0 0;color:var(--color-muted)}
-.post{padding:34px 0 60px}
-.post h1{font-size:32px;line-height:1.2;margin:0 0 10px}
+.desc{margin:8px 0 0;color:var(--color-muted);max-width:68ch}
+
+.post{padding:var(--space-7) 0 60px}
+.post h1{font-size:36px;line-height:1.1;letter-spacing:-0.01em;margin:0 0 var(--space-3)}
+
 .content{margin-top:var(--space-5)}
 .content p{margin:0 0 var(--space-4)}
-.content h2{margin:28px 0 10px;font-size:20px}
+.content h2{margin:var(--space-7) 0 var(--space-3);font-size:22px;line-height:1.25}
+.content h3{margin:var(--space-6) 0 var(--space-2);font-size:18px;line-height:1.3}
+.content ul,.content ol{margin:0 0 var(--space-4);padding-left:1.25em}
+.content li{margin:0 0 var(--space-2)}
+.content blockquote{margin:0 0 var(--space-4);padding:0 0 0 var(--space-4);border-left:3px solid var(--color-border);color:var(--color-muted)}
+.content hr{border:0;border-top:1px solid var(--color-border);margin:var(--space-7) 0}
+
+.content a{color:var(--color-accent)}
+.content a:hover{text-decoration:underline}
+
 .content pre{overflow:auto;padding:14px;border:1px solid var(--color-border);border-radius:var(--radius-2);background:var(--color-surface-2)}
 .content code{font-family:var(--font-mono);font-size:.95em}
+.content :not(pre) > code{background:var(--color-surface-2);border:1px solid var(--color-border);padding:0 6px;border-radius:6px}
+
 .paywall{margin-top:var(--space-7)}
-.paywall-card{border:1px solid var(--color-border);border-radius:var(--radius-3);padding:var(--space-5);background:var(--color-surface-2)}
+.paywall-card{border:1px solid var(--color-border);border-radius:var(--radius-3);padding:var(--space-5);background:var(--color-surface)}
 .paywall-title{font-weight:650;margin-bottom:6px}
 .paywall-meta{color:var(--color-muted);font-size:14px;margin-bottom:12px}
 .btn{appearance:none;border:1px solid var(--color-text);background:var(--color-text);color:var(--color-accent-contrast);border-radius:var(--radius-4);padding:10px 14px;font-weight:600;cursor:pointer}
@@ -95,4 +118,11 @@ a:hover{opacity:.85}
 .bolt11{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;background:var(--color-surface);border:1px solid var(--color-border);padding:10px;border-radius:var(--radius-2);font-size:12px}
 #qrcode{background:var(--color-qr-bg);display:inline-block;padding:10px;border-radius:12px;border:1px solid var(--color-border)}
 .status{margin-top:8px;color:var(--color-muted);font-size:14px}
+
 .site-footer{padding:var(--space-6) 0;border-top:1px solid var(--color-border);color:var(--color-muted);font-size:13px}
+
+@media (max-width: 520px){
+  .hero h1{font-size:36px}
+  .container{padding:0 16px}
+}
+

--- a/themes/classic/theme.css
+++ b/themes/classic/theme.css
@@ -6,27 +6,34 @@
 */
 
 :root{
-  --color-bg:#fff;
-  --color-surface:#fff;
-  --color-surface-2:#fafafa;
-  --color-text:#111;
-  --color-muted:#666;
-  --color-border:#e9e9e9;
-  --color-accent:#111;
-  --color-accent-contrast:#fff;
-  --color-qr-bg:#fff;
+  /* Light scheme — warm minimal */
+  --color-bg:#f6f3ee;
+  --color-surface:#ffffff;
+  --color-surface-2:#fbf9f6;
+  --color-text:#141414;
+  --color-muted:#6f6a63;
+  --color-border:rgba(20,20,20,0.10);
+  --color-accent:#141414;
+  --color-accent-contrast:#ffffff;
+  --color-qr-bg:#ffffff;
 
   --content-max-width:720px;
+  --font-size-base:16px;
+  --line-height-base:1.7;
 }
 
 [data-color-scheme="dark"]{
+  /* Dark scheme — charcoal */
   --color-bg:#0f0f10;
   --color-surface:#171719;
-  --color-surface-2:#1e1e21;
+  --color-surface-2:#1f1f22;
   --color-text:#f2f2f0;
   --color-muted:#a5a19a;
   --color-border:rgba(242,242,240,0.12);
   --color-accent:#f2f2f0;
   --color-accent-contrast:#0f0f10;
-  --color-qr-bg:#fff;
+  --color-qr-bg:#ffffff;
+
+  --font-size-base:16px;
+  --line-height-base:1.7;
 }


### PR DESCRIPTION
Refs #76.

Polishes the default `classic` theme for both schemes:
- Updates classic theme token values (warm off-white light scheme; charcoal dark scheme)
- Refines home hero typography/spacing
- Improves post list rhythm (subtle dividers, summary width)
- Improves Markdown content rendering (h2/h3, lists, blockquotes, hr, inline code)
- Makes paywall card use surface token for better contrast

Smoke tests (bounty local):
- `npm test` ✅
- Server run (PORT=3021): HTML includes theme link + global toggle on `/`, `/p/free-note/`, `/p/hello-paywall/` (locked), `/about/` ✅
- Hex-color guard still clean ✅