### PR TITLE
content: add About page placeholder (refs #88)

### DIFF
--- a/content/posts/about.md
+++ b/content/posts/about.md
@@ -1,0 +1,44 @@
+---
+type: page
+title: About
+slug: about
+published_date: 2026-02-17
+draft: false
+price_sats: 0
+summary: A placeholder About page for Paywritr.
+aliases: []
+topics: []
+---
+
+Paywritr is a hyper-minimal Markdown blog with per-post Lightning paygating.
+
+This page is **dummy content** (placeholder) so you can:
+- verify page routing (`/about/`)
+- see the header nav auto-populate
+- test typography + light/dark mode rendering
+
+## What Paywritr is
+
+- Flat-file Markdown content
+- No user accounts
+- Pay once per post, unlock on this device (cookie)
+
+## What this demo page includes
+
+A simple blockquote:
+
+> This is a placeholder quote to test spacing, borders, and muted text styles.
+
+A short code snippet:
+
+```bash
+# Example only
+THEME=classic
+PAYMENTS_PROVIDER=alby_hub
+```
+
+And a link: <https://github.com/drytidelabs/paywritr>
+
+---
+
+If you want, replace this with real copy later.


### PR DESCRIPTION
Refs #88.

Adds a default About page at `/about/` with dummy content to exercise:
- page routing
- auto pages nav
- classic theme typography + light/dark

Smoke tests (bounty local):
- `npm test` ✅
- Server run (PORT=3022): home shows About nav; `/about/` route renders and contains expected dummy content ✅