### PR TITLE
feat: mustache-style theme template renderer (refs #95)

### DIFF
--- a/lib/template_renderer.js
+++ b/lib/template_renderer.js
@@ -1,0 +1,12 @@
+import Mustache from 'mustache';
+
+// Safe, Mustache-style renderer for theme templates.
+// - Escapes by default (Mustache default)
+// - Triple-stash {{{var}}} is raw HTML (use only for trusted, pre-rendered HTML like markdown output).
+// - No helpers / arbitrary code execution.
+
+export function renderMustache({ template, view, partials = {} }) {
+  if (typeof template !== 'string') throw new Error('template must be a string');
+  // Mustache will HTML-escape variables by default.
+  return Mustache.render(template, view || {}, partials || {});
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "payblog",
+  "name": "paywritr",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "payblog",
+      "name": "paywritr",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -13,6 +13,7 @@
         "express": "^5.2.1",
         "gray-matter": "^4.0.3",
         "marked": "^17.0.2",
+        "mustache": "^4.2.0",
         "nostr-tools": "^2.14.3",
         "ws": "^8.18.0"
       },
@@ -909,6 +910,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "^5.2.1",
     "gray-matter": "^4.0.3",
     "marked": "^17.0.2",
+    "mustache": "^4.2.0",
     "nostr-tools": "^2.14.3",
     "ws": "^8.18.0"
   },

--- a/test/template_renderer.test.js
+++ b/test/template_renderer.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderMustache } from '../lib/template_renderer.js';
+
+test('renderMustache escapes variables by default', () => {
+  const html = renderMustache({
+    template: '<h1>{{title}}</h1>',
+    view: { title: '<script>alert(1)</script>' },
+  });
+  // Mustache escapes '/' as &#x2F;.
+  assert.equal(html, '<h1>&lt;script&gt;alert(1)&lt;&#x2F;script&gt;</h1>');
+});
+
+test('renderMustache allows raw HTML via triple-stash', () => {
+  const html = renderMustache({
+    template: '<div>{{{content_html}}}</div>',
+    view: { content_html: '<p><strong>ok</strong></p>' },
+  });
+  assert.equal(html, '<div><p><strong>ok</strong></p></div>');
+});
+
+test('renderMustache supports partials', () => {
+  const html = renderMustache({
+    template: '<div>{{> header}}</div>',
+    view: { title: 'Hello' },
+    partials: { header: '<h1>{{title}}</h1>' },
+  });
+  assert.equal(html, '<div><h1>Hello</h1></div>');
+});


### PR DESCRIPTION
Refs #95.

Adds a small wrapper around Mustache for safe theme template rendering (`lib/template_renderer.js`). Includes unit tests verifying:
- HTML escaping by default
- triple-stash raw HTML for trusted fields
- partial support

Adds dependency: `mustache`.

CI: `npm test` ✅