### PR TITLE
feat: site.yml global metadata + theme.yml scaffold (refs #93)

### DIFF
--- a/lib/site_metadata.js
+++ b/lib/site_metadata.js
@@ -1,0 +1,55 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import YAML from 'yaml';
+
+const DEFAULT_SITE = {
+  title: 'Paywritr',
+  tagline: '',
+  description: '',
+};
+
+export async function loadSiteMeta({ cwd = process.cwd() } = {}) {
+  const file = path.join(cwd, 'site.yml');
+  let raw;
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return { ...DEFAULT_SITE };
+    throw e;
+  }
+
+  let parsed;
+  try {
+    parsed = YAML.parse(raw) || {};
+  } catch {
+    // Fail soft: if YAML is invalid, fall back to defaults rather than taking the site down.
+    return { ...DEFAULT_SITE };
+  }
+
+  const title = String(parsed.title ?? DEFAULT_SITE.title).trim() || DEFAULT_SITE.title;
+  const tagline = String(parsed.tagline ?? DEFAULT_SITE.tagline).trim();
+  const description = String(parsed.description ?? DEFAULT_SITE.description).trim();
+
+  return { title, tagline, description };
+}
+
+export async function loadThemeMeta({ themeName, cwd = process.cwd() } = {}) {
+  if (!themeName) return null;
+  const file = path.join(cwd, 'themes', themeName, 'theme.yml');
+  let raw;
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return null;
+    return null;
+  }
+
+  try {
+    const parsed = YAML.parse(raw) || {};
+    const label = parsed.label != null ? String(parsed.label).trim() : null;
+    const version = parsed.version != null ? String(parsed.version).trim() : null;
+    return { label, version };
+  } catch {
+    return null;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "marked": "^17.0.2",
         "mustache": "^4.2.0",
         "nostr-tools": "^2.14.3",
-        "ws": "^8.18.0"
+        "ws": "^8.18.0",
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "nodemon": "^3.1.11"
@@ -1451,6 +1452,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "marked": "^17.0.2",
     "mustache": "^4.2.0",
     "nostr-tools": "^2.14.3",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.11"

--- a/server.js
+++ b/server.js
@@ -7,11 +7,11 @@ import fs from 'node:fs/promises';
 
 import { parsePaymentsProvider, createInvoice, checkInvoicePaid } from './lib/payments.js';
 import { scanContent, findCanonical, ContentValidationError } from './lib/content.js';
+import { loadSiteMeta, loadThemeMeta } from './lib/site_metadata.js';
 
 const app = express();
 
 const PORT = process.env.PORT || 3000;
-const SITE_TITLE = process.env.SITE_TITLE || 'PayBlog';
 const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
 
 const PAYMENTS_PROVIDER = parsePaymentsProvider(process.env);
@@ -269,20 +269,28 @@ function escapeHtml(s) {
 }
 
 async function layout({ title, content, extraHead = '', extraBody = '' }) {
-  const themeHref = await resolveThemeCssHref();
-  const pages = await listPages();
+  const [themeHref, pages, site, themeMeta] = await Promise.all([
+    resolveThemeCssHref(),
+    listPages(),
+    loadSiteMeta(),
+    loadThemeMeta({ themeName: THEME }),
+  ]);
+
   const nav = pages.length
     ? `<nav class="site-nav" aria-label="Pages">${pages
         .map((p) => `<a class="nav-link" href="/${encodeURIComponent(p.slug)}/">${escapeHtml(p.title)}</a>`)
         .join('')}</nav>`
     : '';
 
+  const pageTitle = `${escapeHtml(title)} — ${escapeHtml(site.title)}`;
+
   return `<!doctype html>
 <html lang="en" data-color-scheme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>${escapeHtml(title)} — ${escapeHtml(SITE_TITLE)}</title>
+  <title>${pageTitle}</title>
+  ${site.description ? `<meta name="description" content="${escapeHtml(site.description)}" />` : ''}
 
   <script>
     // #72: persist scheme in cookie; if absent, default to system preference.
@@ -317,7 +325,7 @@ async function layout({ title, content, extraHead = '', extraBody = '' }) {
   <header class="site-header">
     <div class="container">
       <div class="site-header-row">
-        <a class="brand" href="/">${escapeHtml(SITE_TITLE)}</a>
+        <a class="brand" href="/">${escapeHtml(site.title)}</a>
         <button id="schemeToggle" class="scheme-toggle" type="button" aria-label="Toggle light/dark mode" aria-pressed="false">Light</button>
       </div>
       ${nav}
@@ -330,7 +338,7 @@ async function layout({ title, content, extraHead = '', extraBody = '' }) {
 
   <footer class="site-footer">
     <div class="container">
-      <span>© ${new Date().getUTCFullYear()} ${escapeHtml(SITE_TITLE)}</span>
+      <span>© ${new Date().getUTCFullYear()} ${escapeHtml(site.title)}</span>
     </div>
   </footer>
 
@@ -343,7 +351,8 @@ async function layout({ title, content, extraHead = '', extraBody = '' }) {
 app.get(
   '/',
   asyncHandler(async (req, res) => {
-    const posts = await listPosts();
+    const [posts, site] = await Promise.all([listPosts(), loadSiteMeta()]);
+
     const items = posts
       .map((p) => {
         const price = p.price_sats > 0 ? `${p.price_sats} sats` : 'free';
@@ -357,11 +366,11 @@ app.get(
 
     res.type('html').send(
       await layout({
-        title: 'Home',
+        title: site.title,
         content: `
       <section class="hero">
-        <h1>${escapeHtml(SITE_TITLE)}</h1>
-        <p class="muted">Minimal writing. Pay per post with Lightning.</p>
+        <h1>${escapeHtml(site.title)}</h1>
+        ${site.tagline ? `<p class="muted">${escapeHtml(site.tagline)}</p>` : ''}
       </section>
       <section class="post-list">${items || '<p class="muted">No posts yet.</p>'}</section>
     `,
@@ -516,7 +525,8 @@ app.get(
     if (post.price_sats <= 0) return res.status(400).json({ error: 'post is free' });
 
     const amount = post.price_sats;
-    const memo = `${SITE_TITLE}: ${post.title} (${slug})`;
+    const site = await loadSiteMeta();
+    const memo = `${site.title}: ${post.title} (${slug})`;
 
     let inv;
     try {

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,6 @@
+# Global site metadata (non-secrets)
+# Themes/templates should use these values for branding + SEO.
+
+title: "Paywritr"
+tagline: "Minimal writing. Pay per post with Lightning."
+description: "Hyper-minimal Markdown blog with per-post Lightning paygating."

--- a/themes/classic/theme.json
+++ b/themes/classic/theme.json
@@ -1,5 +1,0 @@
-{
-  "label": "Classic",
-  "version": "0.1.0",
-  "notes": "Default theme. Identifier is the folder name: classic."
-}

--- a/themes/classic/theme.yml
+++ b/themes/classic/theme.yml
@@ -1,0 +1,3 @@
+label: "Classic"
+version: "0.1.0"
+notes: "Default theme. Identifier is the folder name: classic."


### PR DESCRIPTION
Refs #93.

Adds global site metadata via `site.yml` (title/tagline/description) and loads it in server rendering:
- header brand + footer now use `site.yml:title`
- home hero title + tagline use `site.yml`
- adds meta description when provided

Also switches theme metadata to YAML:
- adds `themes/classic/theme.yml`
- removes `themes/classic/theme.json`

Includes YAML parsing via `yaml` dependency and adds a small loader (`lib/site_metadata.js`).

Smoke tests:
- `npm test` ✅
- server run: home 200 and contains title/tagline/meta description from site.yml ✅