### PR TITLE
feat: theme render context scaffold (refs #96)

### DIFF
--- a/lib/theme_context.js
+++ b/lib/theme_context.js
@@ -1,0 +1,40 @@
+import { loadSiteMeta, loadThemeMeta } from './site_metadata.js';
+import { scanContent } from './content.js';
+
+export async function buildThemeContext({ themeName } = {}) {
+  const [site, themeMeta, scanned] = await Promise.all([
+    loadSiteMeta(),
+    themeName ? loadThemeMeta({ themeName }) : Promise.resolve(null),
+    scanContent(),
+  ]);
+
+  const navPages = scanned.pages
+    .filter((p) => !p.draft)
+    .slice()
+    .sort((a, b) => String(a.title || '').localeCompare(String(b.title || '')))
+    .map((p) => ({ slug: p.slug, title: p.title }));
+
+  const homePosts = scanned.posts
+    .filter((p) => !p.draft)
+    .map((p) => ({
+      type: 'post',
+      slug: p.slug,
+      title: p.title,
+      published_date: p.published_date,
+      summary: p.summary,
+      price_sats: p.price_sats,
+    }));
+
+  return {
+    site,
+    theme: themeMeta,
+    nav: { pages: navPages },
+    home: { posts: homePosts },
+    // global helpers/snippets (optional to render)
+    global: {
+      // This will be replaced by template-driven rendering in #92.
+      // For now, keep as an empty placeholder.
+      scheme_toggle_html: '',
+    },
+  };
+}

--- a/test/theme_context.test.js
+++ b/test/theme_context.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildThemeContext } from '../lib/theme_context.js';
+
+test('buildThemeContext returns site + nav/pages + home/posts', async () => {
+  const ctx = await buildThemeContext({ themeName: 'classic' });
+  assert.ok(ctx.site);
+  assert.ok(typeof ctx.site.title === 'string');
+  assert.ok(ctx.nav);
+  assert.ok(Array.isArray(ctx.nav.pages));
+  assert.ok(ctx.home);
+  assert.ok(Array.isArray(ctx.home.posts));
+});


### PR DESCRIPTION
Refs #96.

Adds `lib/theme_context.js` which builds a stable render context object themes/templates will consume (site, nav pages, home posts, optional theme meta). Includes a basic unit test.

CI: `npm test` ✅