### PR TITLE
feat: theme template resolution + partial loading (refs #94)

### DIFF
--- a/lib/theme_templates.js
+++ b/lib/theme_templates.js
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+function safeJoin(root, ...parts) {
+  // Prevent path traversal by resolving and verifying prefix.
+  const p = path.resolve(root, ...parts);
+  const r = path.resolve(root);
+  if (!p.startsWith(r + path.sep) && p !== r) return null;
+  return p;
+}
+
+async function readFileIfExists(absPath) {
+  if (!absPath) return null;
+  try {
+    return await fs.readFile(absPath, 'utf8');
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return null;
+    return null;
+  }
+}
+
+export function themeRoot({ cwd = process.cwd(), themeName }) {
+  return path.join(cwd, 'themes', themeName || '');
+}
+
+export async function loadThemePartials({ cwd = process.cwd(), themeName }) {
+  if (!themeName) return {};
+  const root = themeRoot({ cwd, themeName });
+  const partialsDir = safeJoin(root, 'partials');
+  if (!partialsDir) return {};
+
+  let entries;
+  try {
+    entries = await fs.readdir(partialsDir, { withFileTypes: true });
+  } catch {
+    return {};
+  }
+
+  const partials = {};
+  for (const ent of entries) {
+    if (!ent.isFile()) continue;
+    if (!ent.name.endsWith('.mustache')) continue;
+    const name = ent.name.replace(/\.mustache$/, '');
+    const abs = safeJoin(partialsDir, ent.name);
+    const txt = await readFileIfExists(abs);
+    if (typeof txt === 'string') partials[name] = txt;
+  }
+
+  return partials;
+}
+
+export async function loadThemeTemplate({ cwd = process.cwd(), themeName, templateName }) {
+  // templateName should be like 'home', 'post', 'layout', etc.
+  if (!themeName || !templateName) return null;
+  const root = themeRoot({ cwd, themeName });
+  const templatesDir = safeJoin(root, 'templates');
+  if (!templatesDir) return null;
+  const abs = safeJoin(templatesDir, `${templateName}.mustache`);
+  return await readFileIfExists(abs);
+}
+
+export async function resolveTemplate({ cwd = process.cwd(), themeName, kind }) {
+  // kind: home|post|page|content|notfound|error|<newtype>
+  // Resolution rules:
+  // 1) try kind-specific template
+  // 2) fall back to content.mustache for unknown/new types
+  // 3) return null (caller should use built-in fallback template)
+
+  const primary = await loadThemeTemplate({ cwd, themeName, templateName: kind });
+  if (primary) return { name: kind, template: primary };
+
+  if (kind !== 'content') {
+    const fallback = await loadThemeTemplate({ cwd, themeName, templateName: 'content' });
+    if (fallback) return { name: 'content', template: fallback };
+  }
+
+  return null;
+}

--- a/test/theme_templates.test.js
+++ b/test/theme_templates.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadThemePartials, resolveTemplate } from '../lib/theme_templates.js';
+
+async function withTmpDir(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'paywritr-theme-'));
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('resolveTemplate prefers kind-specific template and falls back to content.mustache', async () => {
+  await withTmpDir(async (cwd) => {
+    const tdir = path.join(cwd, 'themes', 't1', 'templates');
+    await fs.mkdir(tdir, { recursive: true });
+    await fs.writeFile(path.join(tdir, 'content.mustache'), 'CONTENT', 'utf8');
+    await fs.writeFile(path.join(tdir, 'post.mustache'), 'POST', 'utf8');
+
+    const post = await resolveTemplate({ cwd, themeName: 't1', kind: 'post' });
+    assert.equal(post.name, 'post');
+    assert.equal(post.template, 'POST');
+
+    const note = await resolveTemplate({ cwd, themeName: 't1', kind: 'note' });
+    assert.equal(note.name, 'content');
+    assert.equal(note.template, 'CONTENT');
+  });
+});
+
+test('loadThemePartials loads *.mustache partial files by basename', async () => {
+  await withTmpDir(async (cwd) => {
+    const pdir = path.join(cwd, 'themes', 't1', 'partials');
+    await fs.mkdir(pdir, { recursive: true });
+    await fs.writeFile(path.join(pdir, 'header.mustache'), '<h1>{{site.title}}</h1>', 'utf8');
+
+    const partials = await loadThemePartials({ cwd, themeName: 't1' });
+    assert.equal(typeof partials.header, 'string');
+    assert.ok(partials.header.includes('{{site.title}}'));
+  });
+});


### PR DESCRIPTION
Refs #94.

Adds `lib/theme_templates.js` to support theme template/partial loading with Mustache template resolution rules:
- loads `themes/<theme>/partials/*.mustache` into a partials map
- resolves templates by kind (`post|page|home|...`) with fallback to `content.mustache` for unknown/new types
- safe path join to avoid traversal

Includes unit tests using a temp theme fixture directory.

CI: `npm test` ✅