### PR TITLE
feat: pricing rules + validation (refs #59)

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -111,12 +111,26 @@ export async function scanContent() {
 
     const draft = normBool(fm.draft, false);
 
-    // price_sats rules
-    let price_sats = Number(fm.price_sats ?? 0);
-    if (!Number.isFinite(price_sats) || price_sats < 0) {
-      fail(filePath, 'price_sats', 'price_sats must be a non-negative number');
+    // price_sats rules (#59)
+    const rawPrice = fm.price_sats ?? 0;
+    let price_sats;
+    if (rawPrice === '' || rawPrice === null || rawPrice === undefined) {
+      price_sats = 0;
+    } else {
+      price_sats = Number(rawPrice);
     }
-    price_sats = Math.trunc(price_sats);
+    if (!Number.isFinite(price_sats)) {
+      fail(filePath, 'price_sats', `price_sats must be a non-negative integer (got: ${JSON.stringify(rawPrice)})`);
+    }
+    if (price_sats < 0) {
+      fail(filePath, 'price_sats', `price_sats must be non-negative (got: ${price_sats})`);
+    }
+    if (!Number.isInteger(price_sats)) {
+      fail(filePath, 'price_sats', `price_sats must be an integer, not a float (got: ${rawPrice})`);
+    }
+    if (price_sats > 1_000_000) {
+      console.warn(`[content] WARNING: very high price_sats=${price_sats} in ${filePath} — verify this is intentional`);
+    }
 
     if (type === 'page') {
       if (price_sats !== 0) {

--- a/test/pricing_validation.test.js
+++ b/test/pricing_validation.test.js
@@ -1,0 +1,100 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const CONTENT_DIR = path.join(process.cwd(), 'content', 'posts');
+
+// Helper: write a temp content file, import scanContent fresh, then clean up
+async function withTempContent(filename, frontmatter, body, fn) {
+  const filePath = path.join(CONTENT_DIR, filename);
+  const content = `---\n${frontmatter}\n---\n\n${body}\n`;
+  await fs.writeFile(filePath, content, 'utf8');
+  try {
+    // Dynamic import to get fresh module (scanContent reads filesystem each call)
+    const { scanContent } = await import('../lib/content.js');
+    await fn(scanContent);
+  } finally {
+    await fs.unlink(filePath).catch(() => {});
+  }
+}
+
+describe('Pricing validation (#59)', () => {
+  it('valid integer price_sats passes', async () => {
+    await withTempContent('_test-price-valid.md',
+      'title: Test\ntype: post\nslug: test-price-valid\nprice_sats: 100',
+      'Hello',
+      async (scanContent) => {
+        const { posts } = await scanContent();
+        const p = posts.find(x => x.slug === 'test-price-valid');
+        assert.ok(p, 'post should be found');
+        assert.equal(p.price_sats, 100);
+      }
+    );
+  });
+
+  it('price_sats: 0 is valid (free)', async () => {
+    await withTempContent('_test-price-zero.md',
+      'title: Test\ntype: post\nslug: test-price-zero\nprice_sats: 0',
+      'Hello',
+      async (scanContent) => {
+        const { posts } = await scanContent();
+        const p = posts.find(x => x.slug === 'test-price-zero');
+        assert.ok(p);
+        assert.equal(p.price_sats, 0);
+      }
+    );
+  });
+
+  it('missing price_sats defaults to 0', async () => {
+    await withTempContent('_test-price-missing.md',
+      'title: Test\ntype: post\nslug: test-price-missing',
+      'Hello',
+      async (scanContent) => {
+        const { posts } = await scanContent();
+        const p = posts.find(x => x.slug === 'test-price-missing');
+        assert.ok(p);
+        assert.equal(p.price_sats, 0);
+      }
+    );
+  });
+
+  it('price_sats: -1 fails validation', async () => {
+    await withTempContent('_test-price-neg.md',
+      'title: Test\ntype: post\nslug: test-price-neg\nprice_sats: -1',
+      'Hello',
+      async (scanContent) => {
+        await assert.rejects(() => scanContent(), (err) => {
+          assert.ok(err.message.includes('non-negative'), `expected non-negative error, got: ${err.message}`);
+          return true;
+        });
+      }
+    );
+  });
+
+  it('price_sats: 3.5 fails validation', async () => {
+    await withTempContent('_test-price-float.md',
+      'title: Test\ntype: post\nslug: test-price-float\nprice_sats: 3.5',
+      'Hello',
+      async (scanContent) => {
+        await assert.rejects(() => scanContent(), (err) => {
+          assert.ok(err.message.includes('integer'), `expected integer error, got: ${err.message}`);
+          return true;
+        });
+      }
+    );
+  });
+
+  it('price_sats: "abc" fails validation', async () => {
+    await withTempContent('_test-price-abc.md',
+      'title: Test\ntype: post\nslug: test-price-abc\nprice_sats: abc',
+      'Hello',
+      async (scanContent) => {
+        await assert.rejects(() => scanContent(), (err) => {
+          assert.ok(err.message.includes('price_sats'), `expected price_sats error, got: ${err.message}`);
+          return true;
+        });
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Changes
- Tighten price_sats validation: reject NaN, strings, floats, negatives
- Missing defaults to 0 (free)
- Soft warning for very high values (>1M sats)
- 6 automated tests covering all paths

Closes #59