### PR TITLE
feat: recursive content discovery under content/ (refs #91)

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import matter from 'gray-matter';
 
-const POSTS_DIR = path.join(process.cwd(), 'content', 'posts');
+const CONTENT_DIR = path.join(process.cwd(), 'content');
 const VALID_SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/i;
 
 function normBool(v, defaultValue = false) {
@@ -52,13 +52,16 @@ function validateSlug(filePath, slug) {
 }
 
 export async function scanContent() {
-  let files;
+  let entries;
   try {
-    files = await fs.readdir(POSTS_DIR);
+    entries = await fs.readdir(CONTENT_DIR, { recursive: true });
   } catch (e) {
     if (e && e.code === 'ENOENT') return { posts: [], pages: [], byTypeSlug: new Map(), aliases: new Map() };
     throw e;
   }
+
+  // Filter to .md files and build absolute paths
+  const mdFiles = entries.filter((x) => x.endsWith('.md')).map((rel) => path.join(CONTENT_DIR, rel));
 
   const posts = [];
   const pages = [];
@@ -66,9 +69,8 @@ export async function scanContent() {
   const allSlugs = new Map(); // slug => filePath
   const aliasToCanonical = new Map(); // alias => { type, slug }
 
-  for (const f of files.filter((x) => x.endsWith('.md'))) {
-    const filePath = path.join(POSTS_DIR, f);
-    const filenameSlug = f.replace(/\.md$/, '');
+  for (const filePath of mdFiles) {
+    const filenameSlug = path.basename(filePath).replace(/\.md$/, '');
 
     let raw;
     try {

--- a/test/recursive_content.test.js
+++ b/test/recursive_content.test.js
@@ -1,0 +1,100 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const CONTENT_DIR = path.join(process.cwd(), 'content');
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function writeContent(relPath, frontmatter, body) {
+  const filePath = path.join(CONTENT_DIR, relPath);
+  await ensureDir(path.dirname(filePath));
+  await fs.writeFile(filePath, `---\n${frontmatter}\n---\n\n${body}\n`, 'utf8');
+  return filePath;
+}
+
+async function removeContent(relPath) {
+  const filePath = path.join(CONTENT_DIR, relPath);
+  await fs.unlink(filePath).catch(() => {});
+}
+
+async function removeDirIfEmpty(relPath) {
+  const dirPath = path.join(CONTENT_DIR, relPath);
+  try {
+    await fs.rmdir(dirPath);
+  } catch {}
+}
+
+describe('Recursive content discovery (#91)', () => {
+  const testFiles = [];
+
+  after(async () => {
+    // Clean up all test files
+    for (const f of testFiles) {
+      await removeContent(f);
+    }
+    // Clean up test dirs
+    await removeDirIfEmpty('nested/deep');
+    await removeDirIfEmpty('nested');
+    await removeDirIfEmpty('pages');
+  });
+
+  it('content in content/posts/ still works (backward compat)', async () => {
+    // existing files like free-note.md should work
+    const { scanContent } = await import('../lib/content.js');
+    const { posts } = await scanContent();
+    const freeNote = posts.find(p => p.slug === 'free-note');
+    assert.ok(freeNote, 'free-note should be discovered in content/posts/');
+  });
+
+  it('content in content/pages/ subdirectory is discovered', async () => {
+    const relPath = 'pages/test-page-subdir.md';
+    testFiles.push(relPath);
+    await writeContent(relPath,
+      'title: Test Page Subdir\ntype: page\nslug: test-page-subdir\nprice_sats: 0',
+      'Page in subdir'
+    );
+
+    const { scanContent } = await import('../lib/content.js');
+    const { pages } = await scanContent();
+    const found = pages.find(p => p.slug === 'test-page-subdir');
+    assert.ok(found, 'page in content/pages/ should be discovered');
+  });
+
+  it('content in deeply nested directory is discovered', async () => {
+    const relPath = 'nested/deep/test-deep-post.md';
+    testFiles.push(relPath);
+    await writeContent(relPath,
+      'title: Deep Post\ntype: post\nslug: test-deep-post\nprice_sats: 0',
+      'Deeply nested post'
+    );
+
+    const { scanContent } = await import('../lib/content.js');
+    const { posts } = await scanContent();
+    const found = posts.find(p => p.slug === 'test-deep-post');
+    assert.ok(found, 'post in content/nested/deep/ should be discovered');
+  });
+
+  it('duplicate slugs across directories produce validation error', async () => {
+    const relPath = 'pages/free-note-dup.md';
+    testFiles.push(relPath);
+    // free-note already exists in content/posts/
+    await writeContent(relPath,
+      'title: Duplicate\ntype: post\nslug: free-note\nprice_sats: 0',
+      'Duplicate slug'
+    );
+
+    const { scanContent } = await import('../lib/content.js');
+    await assert.rejects(() => scanContent(), (err) => {
+      assert.ok(err.message.includes('duplicate slug'), `expected duplicate slug error, got: ${err.message}`);
+      return true;
+    });
+
+    // Clean up immediately so other tests aren't affected
+    await removeContent(relPath);
+    testFiles.pop();
+  });
+});


### PR DESCRIPTION
## Changes
- Scan all *.md files recursively under content/ (not just content/posts/)
- Subdirectories are purely organizational — frontmatter type/slug is canonical
- Backward compatible with existing content/posts/ layout
- Duplicate slug detection with both file paths in error
- 4 automated tests

Closes #91