### PR TITLE
content: add contact page placeholder

### DIFF
--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -1,0 +1,24 @@
+---
+title: Contact
+type: page
+slug: contact
+price_sats: 0
+---
+
+## Get in Touch
+
+Have a question, feedback, or just want to say hello? I'd love to hear from you.
+
+**Email:** hello@example.com
+
+**Twitter/X:** [@yourhandle](https://x.com/yourhandle)
+
+**Nostr:** `npub1yourpubkeyhere`
+
+### For Business Inquiries
+
+If you're interested in sponsorships, collaborations, or licensing content, drop me a line at **biz@example.com** and I'll get back to you within a few days.
+
+### Bug Reports
+
+Found something broken on the site? Open an issue on [GitHub](https://github.com/yourorg/yourrepo/issues) or shoot me a message — I appreciate it.


### PR DESCRIPTION
Adds a fake contact page at `content/pages/contact.md` (also validates recursive content discovery from #91).

Placeholder emails/handles — swap in real ones when ready.